### PR TITLE
Extends life of monsteres

### DIFF
--- a/contracts/pet/pet.hpp
+++ b/contracts/pet/pet.hpp
@@ -106,7 +106,7 @@ public:
         uint32_t hunger_to_zero = 10 * HOUR;
         uint32_t min_hunger_interval = 3 * HOUR;
         uint8_t  max_hunger_points = 100;
-        uint8_t  hunger_hp_modifier = 1;
+        uint8_t  hunger_hp_modifier = 5;
         uint32_t min_awake_interval = 8 * HOUR;
         uint32_t min_sleep_period = 4 * HOUR;
         uint32_t creation_tolerance = 1 * HOUR;


### PR DESCRIPTION
This PR changes how long a monster can live without feeding.

The factor hunger_hp_modifier is changed from 1 to 5. This implies that the monster still gets hungry after 10 hours, but then still has HP for another 50 hours.

The ricardian contracts still needs to be updated to reflect this change. All users with living monsters need to agree that the monsters can now live longer (and the users RAM is blocked in this contract for longer)