### PR TITLE
added eosio_assert() for overflows in _next_id, _next_element_id, _next_pet_type_id

### DIFF
--- a/contracts/pet/lib/pet.admin.cpp
+++ b/contracts/pet/lib/pet.admin.cpp
@@ -88,6 +88,7 @@ void pet::changepettyp(uint64_t id, vector<uint8_t> elements) {
 uuid pet::_next_id(){
     auto pc = _get_pet_config();
     pc.last_id++;
+    eosio_assert(pc.last_id > 0, "_next_id overflow detected");
     _update_pet_config(pc);
     return pc.last_id;
 }
@@ -95,6 +96,7 @@ uuid pet::_next_id(){
 uint64_t pet::_next_element_id(){
     auto pc = _get_pet_config();
     pc.last_element_id++;
+    eosio_assert(pc.last_element_id > 0, "_next_element_id overflow detected");
     _update_pet_config(pc);
     return pc.last_element_id-1; // zero based id
 }
@@ -102,6 +104,7 @@ uint64_t pet::_next_element_id(){
 uint64_t pet::_next_pet_type_id(){
     auto pc = _get_pet_config();
     pc.last_pet_type_id++;
+    eosio_assert(pc.last_pet_type_id > 0, "_next_pet_type_id overflow detected");
     _update_pet_config(pc);
     return pc.last_pet_type_id-1; // zero based id
 }
@@ -140,4 +143,5 @@ pet::st_pet_config2 pet::_get_pet_config(){
 void pet::_update_pet_config(const st_pet_config2 &pc) {
   pet_config2.set(pc, _self);
 }
+
 


### PR DESCRIPTION
There is a possibility that the global count for the named ids could overflow and overwrite existing data. 