### PR TITLE
Load more rows in Rankings

### DIFF
--- a/services/frontend/src/modules/ranking/EldestRank.tsx
+++ b/services/frontend/src/modules/ranking/EldestRank.tsx
@@ -38,20 +38,13 @@ class EldestRank extends React.Component<{}, ReactState> {
 
           const monsters = allPets ? allPets.edges : []
 
-          const onLoadMore = () => {
-            // tslint:disable-next-line:no-console
-            console.log("length" + allPets.edges.length)
+          const onLoadMore = () => {            
             
             fetchMore({
               variables: {
                 offset: allPets.edges.length
               },
-              updateQuery: (prev, { fetchMoreResult }) => {
-                // tslint:disable-next-line:no-console
-                console.log("more "+ JSON.stringify(fetchMoreResult))
-                // tslint:disable-next-line:no-console
-                console.log("prev "+ JSON.stringify(prev))
-                
+              updateQuery: (prev, { fetchMoreResult }) => {                
                 if (!fetchMoreResult) { 
                   this.setState({loadMore:false})
                   return prev 

--- a/services/frontend/src/modules/ranking/EldestRank.tsx
+++ b/services/frontend/src/modules/ranking/EldestRank.tsx
@@ -18,7 +18,7 @@ class EldestRank extends React.Component<{}, ReactState> {
   public render() {
 
     const variables = {
-      limit: 2,
+      limit: 21,
       offset: 0
     }
     const {loadMore} = this.state

--- a/services/frontend/src/modules/ranking/TopActivityRank.tsx
+++ b/services/frontend/src/modules/ranking/TopActivityRank.tsx
@@ -6,19 +6,26 @@ import TitleBar from "../shared/TitleBar"
 import { QUERY_TOP_ACTIVITY } from "./ranking.gql"
 import { monsterImageSrc } from "../monsters/monsters"
 
-class TopActivityRank extends React.Component<{}, {}> {
+interface ReactState {
+  loadMore:boolean
+}
+class TopActivityRank extends React.Component<{}, ReactState> {
 
+  public state = {
+    loadMore:true
+  }
   public render() {
 
     const variables = {
       limit: 21,
       offset: 0
     }
+    const {loadMore} = this.state
 
     return <div className="rank">
       <TitleBar title="Top Activity Monsters" />
       <Query query={QUERY_TOP_ACTIVITY} variables={variables}>
-        {({data, loading, refetch}) => {
+        {({data, loading, fetchMore}) => {
 
           if (loading || !data || !data.allVrankingActives) {
             return <span>
@@ -29,7 +36,27 @@ class TopActivityRank extends React.Component<{}, {}> {
           const { allVrankingActives } = data
 
           const monsters = allVrankingActives ? allVrankingActives.edges : []
-          return <table>
+
+          const onLoadMore = () => {            
+            
+            fetchMore({
+              variables: {
+                offset: monsters.length
+              },
+              updateQuery: (prev, { fetchMoreResult }) => {                
+                if (!fetchMoreResult) { 
+                  this.setState({loadMore:false})
+                  return prev 
+                }              
+                this.setState({loadMore:fetchMoreResult.allVrankingActives.edges.length === variables.limit })
+                return Object.assign({}, prev, {allVrankingActives : 
+                  Object.assign({}, prev.allVrankingActives, {edges:[...prev.allVrankingActives.edges, ...fetchMoreResult.allVrankingActives.edges]})
+                  })
+            }})
+          }
+
+          return <div>
+            <table>
             <thead>
               <tr>
                 <th>#</th>
@@ -52,6 +79,15 @@ class TopActivityRank extends React.Component<{}, {}> {
             ))}
             </tbody>
           </table>
+          {loadMore &&
+            <footer className="card-footer">
+              <a className="card-footer-item"
+                onClick={onLoadMore}>
+                Load more
+              </a>
+            </footer> 
+          }
+        </div>
         }}
       </Query>
     </div>

--- a/services/frontend/src/modules/ranking/TopBattlePlayersRank.tsx
+++ b/services/frontend/src/modules/ranking/TopBattlePlayersRank.tsx
@@ -44,8 +44,8 @@ class TopBattlePlayersRank extends React.Component<{}, ReactState> {
                   return prev 
                 }              
                 this.setState({loadMore:fetchMoreResult.allVrankingBattlePlayers.edges.length === variables.limit })
-                return Object.assign({}, prev, {allVrankingBattlePets : 
-                  Object.assign({}, prev.allVrankingBattlePets, {edges:[...prev.allVrankingBattlePets.edges, ...fetchMoreResult.allVrankingBattlePets.edges]})
+                return Object.assign({}, prev, {allVrankingBattlePlayers : 
+                  Object.assign({}, prev.allVrankingBattlePlayers, {edges:[...prev.allVrankingBattlePlayers.edges, ...fetchMoreResult.allVrankingBattlePlayers.edges]})
                   })
               }
             })

--- a/services/frontend/src/modules/ranking/TopCollectorsRank.tsx
+++ b/services/frontend/src/modules/ranking/TopCollectorsRank.tsx
@@ -4,8 +4,15 @@ import { Query } from "react-apollo"
 import TitleBar from "../shared/TitleBar"
 import { QUERY_TOP_COLLECTORS } from "./ranking.gql"
 
-class TopCollectorsRank extends React.Component<{}, {}> {
+interface ReactState {
+  loadMore:boolean
+}
 
+class TopCollectorsRank extends React.Component<{}, ReactState> {
+
+  public state = {
+    loadMore: true
+  }
   public render() {
 
     const variables = {
@@ -13,10 +20,12 @@ class TopCollectorsRank extends React.Component<{}, {}> {
       offset: 0
     }
 
+    const {loadMore} = this.state
+
     return <div className="rank">
       <TitleBar title="Top Collectors Players" />
       <Query query={QUERY_TOP_COLLECTORS} variables={variables}>
-        {({data, loading, refetch}) => {
+        {({data, loading, fetchMore}) => {
 
           if (loading || !data || !data.allVrankingCollectors) {
             return <span>
@@ -25,7 +34,25 @@ class TopCollectorsRank extends React.Component<{}, {}> {
           }
 
           const monsters = data.allVrankingCollectors ? data.allVrankingCollectors.edges : []
-          return <table>
+          const onLoadMore = () => {            
+            
+            fetchMore({
+              variables: {
+                offset: monsters.length
+              },
+              updateQuery: (prev, { fetchMoreResult }) => {                
+                if (!fetchMoreResult) { 
+                  this.setState({loadMore:false})
+                  return prev 
+                }              
+                this.setState({loadMore:fetchMoreResult.allVrankingCollectors.edges.length === variables.limit })
+                return Object.assign({}, prev, {allVrankingCollectors : 
+                  Object.assign({}, prev.allVrankingCollectors, {edges:[...prev.allVrankingCollectors.edges, ...fetchMoreResult.allVrankingCollectors.edges]})
+                  })
+            }})
+          }
+          return <div>
+            <table>
             <thead>
               <tr>
                 <th>#</th>
@@ -43,6 +70,15 @@ class TopCollectorsRank extends React.Component<{}, {}> {
             ))}
             </tbody>
           </table>
+          {loadMore &&
+            <footer className="card-footer">
+              <a className="card-footer-item"
+                onClick={onLoadMore}>
+                Load more
+              </a>
+            </footer> 
+          }
+        </div>
         }}
       </Query>
     </div>


### PR DESCRIPTION
This PR
* adds a "Load more" button at the bottom of each ranking that loads more rows. The button disappears once all rows have been loaded

![bildschirmfoto von 2018-09-19 08-33-48](https://user-images.githubusercontent.com/1449049/45735068-f4e01b00-bbe6-11e8-9fa7-5d0ad3ab322e.png)


