### PR TITLE
devtools: add cleos.sh script

### DIFF
--- a/cleos.sh
+++ b/cleos.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Usage:
+# Go into cmd loop: sudo ./cleos.sh
+# Run single cmd:  sudo ./cleos.sh <cleos paramers>
+
+PREFIX="docker-compose exec eosiodev cleos --url http://localhost:8888"
+if [ -z $1 ] ; then
+  while :
+  do
+    read -e -p "cleos " cmd
+    history -s "$cmd"
+    $PREFIX $cmd
+  done
+else
+  $PREFIX "$@"
+fi


### PR DESCRIPTION
Example usage: 

```
➜  monstereos git:(cleos) ./cleos.sh get account monsterusera
permissions:
     owner     1:    1 EOS5k6Jht1epqZ2mnRLFVDXDTosaTneR6xFhvenVLiFfz5Ue125dL
        active     1:    1 EOS5k6Jht1epqZ2mnRLFVDXDTosaTneR6xFhvenVLiFfz5Ue125dL
memory:
     quota:     1.638 MiB    used:      3.76 KiB

net bandwidth:
     staked:         10.0000 SYS           (total stake delegated from account to self)
     delegated:       0.0000 SYS           (total staked delegated to account from others)
     used:               113 bytes
     available:        52.89 MiB
     limit:            52.89 MiB

cpu bandwidth:
     staked:         10.0000 SYS           (total stake delegated from account to self)
     delegated:       0.0000 SYS           (total staked delegated to account from others)
     used:             2.258 ms
     available:        10.56 sec
     limit:            10.56 sec

producers:     <not voted>
```